### PR TITLE
Feat/new profiles flow

### DIFF
--- a/Assets/Plugins/ExecutionController/Runtime/AssetProfile.cs
+++ b/Assets/Plugins/ExecutionController/Runtime/AssetProfile.cs
@@ -43,7 +43,6 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 
 		public static IEnumerator FetchByUri(	
 			string uri,
-			string fullId,
 			Action<AssetProfile> onComplete,
 			string[] variantsOverride = null)
 		{
@@ -53,7 +52,7 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 			yield return resourceHandler.Get(data => profile = data);
 			if (profile == null)
 			{
-				Debug.LogError($"No asset profile found for {fullId}");
+				Debug.LogError($"No asset profile found at {uri}");
 				onComplete?.Invoke(null);
 				yield break;
 			}
@@ -61,54 +60,13 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 			var profileData = GetProfileData(profile, variantsOverride);
 			if (profileData == null)
 			{
-				Debug.LogError($"No asset profile with supported variant and version found for {fullId}.");
+				Debug.LogError($"No asset profile with supported variant and version found at {uri}.");
 				yield break;
 			}
 
 			yield return FromProfileData(profileData, onComplete);
 		}
 		
-		// This will be removed next release once all profiles are uploaded to AR and confirmed working
-		public static IEnumerator FetchByUriLegacy(
-			string uri,
-			string tokenId,
-			Action<AssetProfile> onComplete,
-			string[] variantsOverride = null)
-		{
-			var resourceHandler = new JsonResourceLoader<Dictionary<string, AssetProfileJson>>(uri);
-
-			Dictionary<string, AssetProfileJson> profileCollectionData = null;
-			yield return resourceHandler.Get(data => profileCollectionData = data);
-			if (profileCollectionData == null)
-			{
-				Debug.LogError($"No asset profile collection found at url {uri}");
-				onComplete?.Invoke(null);
-				yield break;
-			}
-
-			// Need to check if override profile exists
-			if (!profileCollectionData.TryGetValue("override", out var profile))
-			{
-				profile = profileCollectionData[tokenId];
-			}
-
-			if (profile == null)
-			{
-				Debug.LogError($"No asset profile found with asset name {tokenId}, and no override profile provided");
-				onComplete?.Invoke(null);
-				yield break;
-			}
-
-			var profileData = GetProfileData(profile, variantsOverride);
-			if (profileData == null)
-			{
-				Debug.LogError($"No asset profile with supported variant and version found for {tokenId}.");
-				yield break;
-			}
-
-			yield return FromProfileData(profileData, onComplete);
-		}
-
 		private static AssetProfileData GetProfileData(AssetProfileJson profile, string[] variantsOverride = null)
 		{
 			var supportedVariants = variantsOverride ??

--- a/Assets/Plugins/ExecutionController/Runtime/AssetProfile.cs
+++ b/Assets/Plugins/ExecutionController/Runtime/AssetProfile.cs
@@ -23,6 +23,8 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 		public string ParsingBlueprintId;
 		[JsonProperty(PropertyName = "parsing-catalog")]
 		public string ParsingCatalogUri;
+		[JsonProperty(PropertyName = "standard-version")]
+		public string StandardVersion;
 	}
 
 	[JsonObject]
@@ -87,8 +89,20 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 			{
 				return null;
 			}
-			
-			var validVersions = variant.Keys.Select(Version.Parse)
+
+			var validVersions = variant.Keys.Select(
+					k =>
+					{
+						try
+						{
+							return Version.Parse(variant[k].StandardVersion);
+						}
+						catch (Exception)
+						{
+							return null;
+						}
+					}
+				)
 				.Where(v => v != null && v.IsSupported())
 				.ToList();
 			

--- a/Assets/Plugins/ExecutionController/Runtime/AssetRegisterInventoryItem.cs
+++ b/Assets/Plugins/ExecutionController/Runtime/AssetRegisterInventoryItem.cs
@@ -17,7 +17,6 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 	public class AssetRegisterInventoryItem : IInventoryItem
 	{
 		public string Id { get; private set; }
-		public string Name => $"{_collectionId}:{_tokenId}";
 		public AssetProfile AssetProfile { get; private set; }
 		public JObject Metadata { get; private set; }
 		public Dictionary<string, IInventoryItem> Children { get; private set; }
@@ -31,9 +30,6 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 
 		private static readonly Dictionary<string, AssetRegisterInventoryItem> s_cachedInventoryItems = new();
 		private static string s_assetProfileKey;
-		
-		private string _collectionId;
-		private string _tokenId;
 
 		public static IEnumerator FromData(
 			IClient client,
@@ -88,18 +84,17 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 				callback?.Invoke(inventoryAsset);
 				yield break;
 			}
-			
-			inventoryAsset = new AssetRegisterInventoryItem();
-			
-			if (asset.Id == null)
+
+			if (asset.TokenId == null || asset.CollectionId == null)
 			{
-				Debug.LogError("Asset is missing field 'Id'. You must include this in the Asset Register query.");
+				Debug.LogError("Asset is missing TokenID and/or CollectionID. You must include these in the Asset Register query");
 				yield break;
 			}
-			inventoryAsset.Id = asset.Id;
 			
-			inventoryAsset._collectionId = asset.CollectionId;
-			inventoryAsset._tokenId = asset.TokenId;
+			inventoryAsset = new AssetRegisterInventoryItem
+			{
+				Id = $"{asset.CollectionId}:{asset.TokenId}",
+			};
 
 			yield return RetrieveMissingData(
 				client,

--- a/Assets/Plugins/ExecutionController/Runtime/ExecutionController.cs
+++ b/Assets/Plugins/ExecutionController/Runtime/ExecutionController.cs
@@ -78,7 +78,7 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 		{
 			if (item.AssetProfile == null)
 			{
-				Debug.LogWarning($"Item {item.Name} does not have an Asset Profile, skipping...");
+				Debug.LogWarning($"Item {item.Id} does not have an Asset Profile, skipping...");
 				yield break;
 			}
 			

--- a/Assets/Plugins/ExecutionController/Runtime/IInventoryItem.cs
+++ b/Assets/Plugins/ExecutionController/Runtime/IInventoryItem.cs
@@ -8,7 +8,6 @@ namespace Futureverse.UBF.UBFExecutionController.Runtime
 	public interface IInventoryItem
 	{
 		string Id { get; }
-		string Name { get; }
 		AssetProfile AssetProfile { get; }
 		JObject Metadata { get; }
 		Dictionary<string, IInventoryItem> Children { get; }

--- a/Assets/Plugins/ExecutionController/Runtime/Settings/ExecutionControllerSettings.cs
+++ b/Assets/Plugins/ExecutionController/Runtime/Settings/ExecutionControllerSettings.cs
@@ -9,15 +9,21 @@ using System.Collections.Generic;
 using Futureverse.UBF.Runtime.Resources;
 using Futureverse.UBF.UBFExecutionController.Runtime;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Futureverse.UBF.ExecutionController.Runtime.Settings
 {
 	internal class ExecutionControllerSettings : ScriptableObject
 	{
+		internal enum Environment
+		{
+			Staging,
+			Production,
+		}
+		
 		private const string MyCustomSettingsPath = "Assets/Resources/RuntimeSettings/ExecutionControllerSettings.asset";
 
-		[SerializeField] private bool _useAssetRegisterProfiles;
-		[SerializeField] private string _assetProfilesPath;
+		[SerializeField] private Environment _profilesEnvironment = Environment.Production;
 		[SerializeField] [Tooltip("List of Variants that can be loaded, in order of load preference")]
 		private string[] _supportedVariants;
 		[SerializeReference] private List<IDownloader> _downloaders;
@@ -25,10 +31,9 @@ namespace Futureverse.UBF.ExecutionController.Runtime.Settings
 		[SerializeField, Tooltip("If blank, uses Application.temporaryCachePath by default")] 
 		private string _cachePathOverride;
 		[SerializeField] private string _syloResolverUri;
-			
-		public string AssetProfilesPath => _assetProfilesPath;
+
+		public Environment ProfilesEnvironment => _profilesEnvironment;
 		public string[] SupportedVariants => _supportedVariants;
-		public bool UseAssetRegisterProfiles => _useAssetRegisterProfiles;
 		public List<IDownloader> Downloaders => _downloaders;
 		public CacheType CacheType => _cacheType;
 		public string CachePathOverride => _cachePathOverride;

--- a/Assets/Plugins/ExecutionController/Runtime/Settings/ExecutionControllerSettingsProvider.cs
+++ b/Assets/Plugins/ExecutionController/Runtime/Settings/ExecutionControllerSettingsProvider.cs
@@ -50,12 +50,7 @@ namespace Futureverse.UBF.ExecutionController.Runtime.Settings
 		{
 			EditorGUI.BeginChangeCheck();
 			s_serializedSettings ??= ExecutionControllerSettings.GetSerializedSettings();
-			var useARProfilesProperty = s_serializedSettings.FindProperty("_useAssetRegisterProfiles");
-			EditorGUILayout.PropertyField(useARProfilesProperty);
-			if (!useARProfilesProperty.boolValue)
-			{
-				EditorGUILayout.PropertyField(s_serializedSettings.FindProperty("_assetProfilesPath"));
-			}
+			EditorGUILayout.PropertyField(s_serializedSettings.FindProperty("_profilesEnvironment"));
 			EditorGUILayout.PropertyField(s_serializedSettings.FindProperty("_syloResolverUri"));
 			
 			var caching = s_serializedSettings.FindProperty("_cacheType");

--- a/Assets/Plugins/ExecutionController/package.json
+++ b/Assets/Plugins/ExecutionController/package.json
@@ -10,7 +10,7 @@
   "changelogUrl": "https://github.com/futureversecom/sdk-unity-execution-controller/blob/main/CHANGELOG.md",
   "licensesUrl": "https://github.com/futureversecom/sdk-unity-execution-controller/blob/main/LICENSE",
   "dependencies": {
-    "com.futureverse.sdk-unity-asset-register": "0.8.4",
+    "com.futureverse.sdk-unity-asset-register": "0.9.1",
     "com.futureverse.sdk-unity-futurepass": "0.3.1",
     "com.futureverse.sdk-unity-sylo": "0.3.1",
     "com.futureverse.ubf": "0.4.1"

--- a/Assets/Resources/RuntimeSettings/ExecutionControllerSettings.asset
+++ b/Assets/Resources/RuntimeSettings/ExecutionControllerSettings.asset
@@ -12,8 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ef19ef67658843958b5603e1b6a302b6, type: 3}
   m_Name: ExecutionControllerSettings
   m_EditorClassIdentifier: 
-  _useAssetRegisterProfiles: 0
-  _assetProfilesPath: https://fv-ubf-assets-dev.s3.us-west-2.amazonaws.com/Genesis/Profiles/1.0
+  _environment: 1
   _supportedVariants:
   - Default
   _downloaders:

--- a/Assets/Testbed/AssetTree/AssetTreeInventoryItem.cs
+++ b/Assets/Testbed/AssetTree/AssetTreeInventoryItem.cs
@@ -18,7 +18,6 @@ public class AssetTreeInventoryItem : IInventoryItem
     [SerializeField] private List<AssetTreeInventoryItem> _children;
     
     public string Id => _id;
-    public string Name => _id;
     public AssetProfile AssetProfile { get; private set; }
     public JObject Metadata { get; private set; }
     public Dictionary<string, IInventoryItem> Children { get; private set; }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "com.unity.nuget.newtonsoft-json": "3.2.1"
       },
-      "hash": "5c74a60792dbf401b660f8ffc9ba811a6d4ed42b"
+      "hash": "0da12401ef5776cb69b8e794db606a3a5a7f6352"
     },
     "com.futureverse.sdk-unity-futurepass": {
       "version": "https://github.com/futureversecom/sdk-unity-futurepass.git",


### PR DESCRIPTION
Removes legacy method of retrieving Asset Profiles. AssetRegisterInventoryItem now checks the settings to see whether to fetch production (default) or staging Asset Profiles. Removed Name property from IInventoryAsset as it was unnecessary. AssetProfile script now also handles sorting the collection version based on the new standard-version field that Asset Profiles contain